### PR TITLE
Configureable timeouts, enable logging to files

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,27 +27,32 @@ The jail directory where chroot() will be performed before dropping privileges. 
 
 The user and group under which HAProxy should run. Only change this if you know what you're doing!
 
-    haproxy_frontend_name: 'hafrontend'
-    haproxy_frontend_bind_address: '*'
-    haproxy_frontend_port: 80
-    haproxy_frontend_mode: 'http'
+    haproxy_frontends:
+    - name: 'hafrontend'
+      address: '*:80'
+      mode: 'http'
+      backend: 'habackend'
+      # Optional:
+      timeout client: 10s
 
-HAProxy frontend configuration directives.
+List of HAProxy frontends.
 
-    haproxy_backend_name: 'habackend'
-    haproxy_backend_mode: 'http'
-    haproxy_backend_balance_method: 'roundrobin'
-    haproxy_backend_httpchk: 'HEAD / HTTP/1.1\r\nHost:localhost'
-
-HAProxy backend configuration directives.
-
-    haproxy_backend_servers:
+    haproxy_backends:
+    - name: 'habackend'
+      # All fields are optional apart from servers
+      mode: 'http'
+      balance_method: 'roundrobin'
+      options:
+      - "haproxy_backend_httpchk: 'HEAD / HTTP/1.1\r\nHost:localhost'"
+      servers:
       - name: app1
         address: 192.168.0.1:80
       - name: app2
         address: 192.168.0.2:80
+      timeout connect 5s
+      timeout server 20s
 
-A list of backend servers (name and address) to which HAProxy will distribute requests.
+List of HAProxy backends and servers to which HAProxy will distribute requests.
 
     haproxy_global_vars:
       - 'ssl-default-bind-ciphers ABCD+KLMJ:...'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,18 @@ haproxy_backends: []
 
 # Extra global vars (see README for example usage).
 haproxy_global_vars: []
+
+# If you want to log to a file you need to configure rsyslog, but this may
+# have global effects on syslog
+# This variable is for convenience, set to True if this is the only role
+# that will be configuring rsyslog
+haproxy_syslog_configure_udp: False
+
+# The sylog destination, e.g. 'local2', default disabled
+haproxy_syslog_dest: ''
+
+# Rotate log files at this interval
+haproxy_logrotate_interval: daily
+
+# Number of backlog files to keep
+haproxy_logrotate_backlog_size: 366

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,3 +2,9 @@
 - name: restart haproxy
   become: yes
   service: name=haproxy state=restarted
+
+- name: restart rsyslog
+  become: yes
+  service:
+    name: rsyslog
+    state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,12 +11,16 @@
     dest: /etc/logrotate.d/haproxy
     src: logrotated-haproxy.j2
 
+# TODO: This is still in development- more configuration is needed to prevent
+# some haproxy logs going to the console, and to potentially take account of
+# other apps using the same syslog facility (probably unlikely)
 - name: configure haproxy log file
   become: yes
   template:
     backup: no
     dest: /etc/rsyslog.d/90-haproxy.conf
     src: rsyslogd-haproxy.j2
+  when: 'haproxy_syslog_dest | length > 0'
   notify:
   - restart rsyslog
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,22 @@
   apt: name=haproxy state=installed
   when: ansible_os_family == 'Debian'
 
+- name: configure haproxy logrotation
+  become: yes
+  template:
+    backup: no
+    dest: /etc/logrotate.d/haproxy
+    src: logrotated-haproxy.j2
+
+- name: configure haproxy log file
+  become: yes
+  template:
+    backup: no
+    dest: /etc/rsyslog.d/90-haproxy.conf
+    src: rsyslogd-haproxy.j2
+  notify:
+  - restart rsyslog
+
 - name: Ensure HAProxy is enabled (so init script will start it on Debian).
   become: yes
   lineinfile:

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -43,6 +43,12 @@ frontend {{ front.name }}
     bind {{ front.address }}
     mode {{ front.mode }}
     default_backend {{ front.backend }}
+{%   for frontopt in front.options | default([]) %}
+    option {{ frontopt }}
+{%   endfor %}
+{%   if front.timeout_client | default('') | length > 0 %}
+    timeout client {{ front.timeout_client }}
+{%   endif %}
 {% endfor %}
 
 {% for back in haproxy_backends %}
@@ -53,15 +59,19 @@ backend {{ back.name }}
 {%   if back.balance_method | default('') | length > 0 %}
     balance {{ back.balance_method }}
 {%   endif %}
-{%   if back.options | default([]) %}
-{%     for backopt in back.options %}
+{%   for backopt in back.options | default([]) %}
     option {{ backopt }}
-{%     endfor %}
-{%   endif %}
+{%   endfor %}
 {%   if back.cookie | default('') | length > 0 %}
     cookie {{ back.cookie }}
 {%   endif %}
 {%   for backend in back.servers %}
     server {{ backend.name }} {{ backend.address }} cookie {{ backend.name }} check
 {%   endfor %}
+{%   if back.timeout_connect | default('') | length > 0 %}
+    timeout connect {{ back.timeout_connect }}
+{%   endif %}
+{%   if back.timeout_server | default('') | length > 0 %}
+    timeout server {{ back.timeout_server }}
+{%   endif %}
 {% endfor %}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -1,6 +1,9 @@
 global
   log /dev/log  local0
   log /dev/log  local1 notice
+{% if haproxy_syslog_dest | default('') | length > 0 %}
+  log 127.0.0.1 {{ haproxy_syslog_dest }}
+{% endif %}
 {% if haproxy_socket != '' %}
   stats socket {{ haproxy_socket }} level admin
 {% endif %}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -46,7 +46,7 @@ frontend {{ front.name }}
     bind {{ front.address }}
     mode {{ front.mode }}
     default_backend {{ front.backend }}
-{%   for frontopt in front.options | default([]) %}
+{%   for frontopt in (front.options | default([])) %}
     option {{ frontopt }}
 {%   endfor %}
 {%   if front.timeout_client | default('') | length > 0 %}
@@ -62,7 +62,7 @@ backend {{ back.name }}
 {%   if back.balance_method | default('') | length > 0 %}
     balance {{ back.balance_method }}
 {%   endif %}
-{%   for backopt in back.options | default([]) %}
+{%   for backopt in (back.options | default([])) %}
     option {{ backopt }}
 {%   endfor %}
 {%   if back.cookie | default('') | length > 0 %}

--- a/templates/logrotated-haproxy.j2
+++ b/templates/logrotated-haproxy.j2
@@ -1,0 +1,15 @@
+# {{ ansible_managed }}
+/var/log/haproxy/*.log {
+    {{ haproxy_logrotate_interval }}
+    missingok
+    rotate {{ haproxy_logrotate_backlog_size }}
+    compress
+    delaycompress
+    notifempty
+    create 640 root adm
+    sharedscripts
+    postrotate
+        /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
+        /bin/kill -HUP `cat /var/run/rsyslogd.pid 2> /dev/null` 2> /dev/null || true
+    endscript
+}

--- a/templates/rsyslogd-haproxy.j2
+++ b/templates/rsyslogd-haproxy.j2
@@ -1,4 +1,4 @@
-{% if haproxy_syslog_dest | default('') | length > 0 %}
+{% if haproxy_syslog_dest | length > 0 %}
 {%   if haproxy_syslog_configure_udp %}
 # Provides UDP syslog reception
 $ModLoad imudp

--- a/templates/rsyslogd-haproxy.j2
+++ b/templates/rsyslogd-haproxy.j2
@@ -1,0 +1,10 @@
+{% if haproxy_syslog_dest | default('') | length > 0 %}
+{%   if haproxy_syslog_configure_udp %}
+# Provides UDP syslog reception
+$ModLoad imudp
+$UDPServerRun 514
+$AllowedSender UDP, 127.0.0.1
+{%   endif %}
+
+{{ haproxy_syslog_dest }}.* /var/log/haproxy/haproxy.log
+{% endif %}


### PR DESCRIPTION
- Adds options for configuring different timeouts (e.g. omero will want a timeout significantly loger than a typical web timeout).
- Adds optional logging to `/var/log/haproxy/haproxy.log` (default is to log to syslog)
  - This includes logrotation (untested)
- Updates the readme which was out of date.

Tag: Something to indicate it's a devel version since more changes will be needed to the logging format to make it useful.