### PR TITLE
cookies and check should be configurable

### DIFF
--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -69,7 +69,8 @@ backend {{ back.name }}
     cookie {{ back.cookie }}
 {%   endif %}
 {%   for backend in back.servers %}
-    server {{ backend.name }} {{ backend.address }} {% if back.cookie | default('') | length > 0 %}cookie {{ backend.name }}{% endif %} {% if back.check | default(True) %}check{% endif %} #
+    server {{ backend.name }} {{ backend.address }} {% if back.cookie | default('') | length > 0 %}cookie {{ backend.name }}{% endif %} {% if back.check | default(True) %}check{% endif %}
+
 {%   endfor %}
 {%   if back.timeout_connect | default('') | length > 0 %}
     timeout connect {{ back.timeout_connect }}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -69,7 +69,7 @@ backend {{ back.name }}
     cookie {{ back.cookie }}
 {%   endif %}
 {%   for backend in back.servers %}
-    server {{ backend.name }} {{ backend.address }} cookie {{ backend.name }} check
+    server {{ backend.name }} {{ backend.address }} {% if back.cookie | default('') | length > 0 %}cookie {{ backend.name }}{% endif %} {% if back.check | default(True) %}check{% endif %} #
 {%   endfor %}
 {%   if back.timeout_connect | default('') | length > 0 %}
     timeout connect {{ back.timeout_connect }}


### PR DESCRIPTION
The cookies param is only for web proxying.
Checks should be optional though are enabled by default.

Tag: probably `2.1.0`?