### PR TITLE
Allow completely custom cfg template to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ List of HAProxy backends and servers to which HAProxy will distribute requests.
 
 A list of extra global variables to add to the global configuration section inside `haproxy.cfg`.
 
+Advanced users can override the template used for `haproxy.cfg` by setting `haproxy_cfg_template`. In this case most of the above role variables will be ignored unless the default template is copied.
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,3 +24,6 @@ haproxy_logrotate_interval: daily
 
 # Number of backlog files to keep
 haproxy_logrotate_backlog_size: 366
+
+# haproxy template source
+haproxy_cfg_template: haproxy.cfg.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -63,7 +63,7 @@
 - name: Copy HAProxy configuration in place.
   become: yes
   template:
-    src: haproxy.cfg.j2
+    src: "{{ haproxy_cfg_template }}"
     dest: /etc/haproxy/haproxy.cfg
     mode: 0644
     validate: haproxy -f %s -c -q


### PR DESCRIPTION
For complex multi-server configurations it's easier to directly template a loop instead of trying to construct an array that gets passed into the template.

Tag: `2.2.0`