### PR TITLE
Updates to the cfg template

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The user and group under which HAProxy should run. Only change this if you know 
 
     haproxy_frontends:
     - name: 'hafrontend'
-      address: '*:80'
+      address: ['*:80']
       mode: 'http'
       backend: 'habackend'
       # Optional:

--- a/playbook.yml
+++ b/playbook.yml
@@ -16,10 +16,10 @@
       haproxy_syslog_configure_udp: True
       haproxy_frontends:
         - name: hafrontend-http
-          address: '*:80'
+          address: ['*:80']
           backend: habackend
         - name: hafrontend-tcp
-          address: '*:81'
+          address: ['*:81']
           mode: tcp
           backend: habackend
       haproxy_backends:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
   become: yes
   package:
     name: haproxy
-    state: installed
+    state: present
 
 - name: configure haproxy logrotation
   become: yes

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -55,7 +55,6 @@ frontend {{ front.name }}
 {%   endif %}
 {% for frontvar in (front.vars | default([])) %}
     {{ frontvar }}
-{%   endfor %}
 {% endfor %}
 {% endfor %}
 
@@ -83,5 +82,5 @@ backend {{ back.name }}
 {%   endif %}
 {% for backvar in (back.vars | default([])) %}
     {{ backvar }}
-{%   endfor %}
+{% endfor %}
 {% endfor %}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -37,7 +37,9 @@ defaults
 
 {% for front in haproxy_frontends %}
 frontend {{ front.name }}
-    bind {{ front.address }}
+{%   for adr in front.address %}
+    bind {{ adr }}
+{%   endfor %}
     mode {{ front.mode | default('http') }}
     default_backend {{ front.backend }}
 {%   for frontopt in (front.options | default([])) %}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -37,8 +37,8 @@ defaults
 
 {% for front in haproxy_frontends %}
 frontend {{ front.name }}
-{%   for adr in front.address %}
-    bind {{ adr }}
+{%   for addr in front.address %}
+    bind {{ addr }}
 {%   endfor %}
     mode {{ front.mode | default('http') }}
     default_backend {{ front.backend }}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -53,6 +53,10 @@ frontend {{ front.name }}
     log 127.0.0.1 {{ haproxy_syslog_dest_tcp }}
 {%     endif %}
 {%   endif %}
+{% for frontvar in (front.vars | default([])) %}
+    {{ frontvar }}
+{%   endfor %}
+{% endfor %}
 {% endfor %}
 
 {% for back in haproxy_backends %}
@@ -77,4 +81,7 @@ backend {{ back.name }}
 {%   if back.timeout_server | default('') | length > 0 %}
     timeout server {{ back.timeout_server }}
 {%   endif %}
+{% for backvar in (back.vars | default([])) %}
+    {{ backvar }}
+{%   endfor %}
 {% endfor %}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -71,7 +71,7 @@ backend {{ back.name }}
     cookie {{ back.cookie }}
 {%   endif %}
 {%   for backend in back.servers %}
-    server {{ backend.name }} {{ backend.address }} {% if back.cookie | default('') | length > 0 %}cookie {{ backend.name }}{% endif %}{{% if backend.opts | default('') }} backend.opts{% endif %} {% if back.check | default(True) %}check{% endif %}
+    server {{ backend.name }} {{ backend.address }} {% if back.cookie | default('') | length > 0 %}cookie {{ backend.name }}{% endif %}{% if backend.opts | default('') %} {{ backend.opts }}{% endif %} {% if back.check | default(True) %}check{% endif %}
 
 {%   endfor %}
 {%   if back.timeout_connect | default('') | length > 0 %}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -71,7 +71,7 @@ backend {{ back.name }}
     cookie {{ back.cookie }}
 {%   endif %}
 {%   for backend in back.servers %}
-    server {{ backend.name }} {{ backend.address }} {% if back.cookie | default('') | length > 0 %}cookie {{ backend.name }}{% endif %} {% if back.check | default(True) %}check{% endif %}
+    server {{ backend.name }} {{ backend.address }} {% if back.cookie | default('') | length > 0 %}cookie {{ backend.name }}{% endif %}{{% if backend.opts | default('') }} backend.opts{% endif %} {% if back.check | default(True) %}check{% endif %}
 
 {%   endfor %}
 {%   if back.timeout_connect | default('') | length > 0 %}


### PR DESCRIPTION
This PR

adds **backend server options** (allows to pass the _send-proxy-v2_ in `server mail01 192.168.1.1 send-proxy-v2 check`), adds **backend parameters** such as the _http-request set-header X-Forwarded-Port %[dst_port]_ in

```
backend host_http
    mode http
    option forwardfor
    option http-server-close
    server host01 2a03:3b40:100::1:20:80  check
    http-request set-header X-Forwarded-Port %[dst_port]
    http-request add-header X-Forwarded-Proto https if { ssl_fc }
```

and adds **support for multiple bind directives** on the frontend to achieve 

```
frontend mail
    bind *:145
    bind *:25
    mode tcp
    default_backend mail
```

While the cfg template file is configurable, there's no other option but the default one. With this PR the cfg gains (imho) basic flexibility it was missing. This also reduces the need to set a custom cfg template to specific cases.

:warning: support for multiple bind directives requires a change to already existing playbooks (string to array).