### PR TITLE
make package name configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+haproxy_package_name: haproxy
 haproxy_socket: /var/lib/haproxy/stats
 haproxy_chroot: /var/lib/haproxy
 haproxy_user: haproxy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Ensure HAProxy is installed
   become: yes
   package:
-    name: haproxy
+    name: "{{ haproxy_package_name }}"
     state: installed
 
 - name: configure haproxy logrotation


### PR DESCRIPTION
When installing newer versions of haproxy (e.g. from SCL repo's) the package name is different and thus making this configurable can be useful.