### PR TITLE
Extract configuration default options and timeouts settings into variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,15 @@ haproxy_backends: []
 # Extra global vars (see README for example usage).
 haproxy_global_vars: []
 
+haproxy_defaults_options:
+  - httplog
+  - dontlognull
+
+haproxy_defaults_timeouts:
+  - connect 5000
+  - client  50000
+  - server  50000
+
 # Set this to True to configure syslog file logging
 haproxy_syslog_enable: False
 

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -20,11 +20,12 @@ global
 defaults
   log global
   mode  http
-  option  httplog
-  option  dontlognull
-  timeout connect 5000
-  timeout client 50000
-  timeout server 50000
+{% for option in haproxy_defaults_options %}
+  option  {{ option }}
+{% endfor %}
+{% for timeout in haproxy_defaults_timeouts %}
+  timeout {{ timeout }}
+{% endfor %}
 {% if ansible_os_family == 'Debian' %}
   errorfile 400 /etc/haproxy/errors/400.http
   errorfile 403 /etc/haproxy/errors/403.http


### PR DESCRIPTION
Hello,

This pull request makes it possible for users of the role to override the default HAproxy options and timeouts (section "defaults" of the configuration file).
Not much is changed but extracting the hardcoded values into variables.

Vincent