### PR TITLE
Add haproxy_additional_configuration setting for free-form config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,5 +40,8 @@ haproxy_logrotate_interval: daily
 # Number of backlog files to keep
 haproxy_logrotate_backlog_size: 366
 
+# Extra configuration added at the end
+haproxy_additional_configuration: ""
+
 # haproxy template source
 haproxy_cfg_template: haproxy.cfg.j2

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -88,3 +88,5 @@ backend {{ back.name }}
     timeout server {{ back.timeout_server }}
 {%   endif %}
 {% endfor %}
+
+{{ haproxy_additional_configuration | default('') }}


### PR DESCRIPTION
Useful to quickly add some configuration that is not supported by the role, such as resolvers.